### PR TITLE
Fix the controller parameters for omni control

### DIFF
--- a/dingo_control/config/teleop_omni.yaml
+++ b/dingo_control/config/teleop_omni.yaml
@@ -1,10 +1,20 @@
 # Teleop configuration for PS4 Navigation joystick
 teleop_twist_joy:
-  axis_linear: 1
-  scale_linear: 0.4
-  scale_linear_turbo: 2.0 # TODO: should this be 1.0?
-  axis_angular: 0
-  scale_angular: 1.4 # TODO: should this be 1.0?
+  axis_linear:
+    x: 1
+    y: 0
+  scale_linear:
+    x: 0.4
+    y: 0.4
+  scale_linear_turbo:
+    x: 2.0 # TODO: should this be 1.0?
+    y: 2.0 # TODO: should this be 1.0?
+  axis_angular:
+    yaw: 3
+  scale_angular:
+    yaw: 1.4 # TODO: should this be 1.0?
+  scale_angular_turbo:
+    yaw: 1.4 # TODO: should this be 1.0?
   enable_button: 4
   enable_turbo_button: 5
 joy_node:


### PR DESCRIPTION
Previous configuration did not allow the omni-directional robot to be moved sideways.  Now the axes are mapped identically to Ridgeback:

- left stick controls forward/backward & left/right translation
- right stick controls left/right rotation