### PR TITLE
Improve joy device configurability

### DIFF
--- a/dingo_control/config/teleop_diff.yaml
+++ b/dingo_control/config/teleop_diff.yaml
@@ -10,4 +10,3 @@ teleop_twist_joy:
 joy_node:
   deadzone: 0.1 # TODO: should this be 0.02?
   autorepeat_rate: 20
-  dev: /dev/input/ps4

--- a/dingo_control/config/teleop_diff.yaml
+++ b/dingo_control/config/teleop_diff.yaml
@@ -1,4 +1,59 @@
-# Teleop configuration for PS4 Navigation joystick
+# Teleop configuration for PS4 joystick using the x-pad configuration.
+# Left thumb-stick up/down for velocity, left/right for twist
+# Left shoulder button for enable
+# Right shoulder button for enable-turbo
+#
+#          L1                                       R1
+#          L2                                       R2
+#       _=====_                                  _=====_
+#      / _____ \                                / _____ \
+#    +.-'_____'-.------------------------------.-'_____'-.+
+#   /   |     |  '.        S O N Y           .'  |  _  |   \
+#  / ___| /|\ |___ \                        / ___| /_\ |___ \      (Y)
+# / |      |      | ;                      ; | _         _ ||
+# | | <---   ---> | |                      | ||_|       (_)||  (X)     (B)
+# | |___   |   ___| ;                      ; |___       ___||
+# |\    | \|/ |    /  _      ____      _   \    | (X) |    /|      (A)
+# | \   |_____|  .','" "',  (_PS_)  ,'" "', '.  |_____|  .' |
+# |  '-.______.-' /       \        /       \  '-._____.-'   |
+# |               |  LJ   |--------|  RJ   |                |
+# |              /\       /        \       /\               |
+# |             /  '.___.'          '.___.'  \              |
+# |            /                              \             |
+#  \          /                                \           /
+#   \________/                                  \_________/
+#
+#          ^ x
+#          |
+#          |
+#  y <-----+      Accelerometer axes
+#           \
+#            \
+#             > z (out)
+#
+# BUTTON         Value
+#   L1             4
+#   L2             6
+#   R1             5
+#   R2             7
+#   A              1
+#   B              2
+#   X              0
+#   Y              3
+#
+#    AXIS        Value
+# Left Horiz.      0
+# Left Vert.       1
+# Right Horiz.     2
+# Right Vert.      5
+#    L2            3
+#    R2            4
+# D-pad Horiz.     9
+# D-pad Vert.      10
+# Accel x          7
+# Accel y          6
+# Accel z          8
+
 teleop_twist_joy:
   axis_linear: 1
   scale_linear: 0.4

--- a/dingo_control/config/teleop_omni.yaml
+++ b/dingo_control/config/teleop_omni.yaml
@@ -20,4 +20,3 @@ teleop_twist_joy:
 joy_node:
   deadzone: 0.1 # TODO: should this be 0.02?
   autorepeat_rate: 20
-  dev: /dev/input/ps4

--- a/dingo_control/config/teleop_omni.yaml
+++ b/dingo_control/config/teleop_omni.yaml
@@ -1,4 +1,60 @@
-# Teleop configuration for PS4 Navigation joystick
+# Teleop configuration for PS4 joystick using the x-pad configuration.
+# Left thumb-stick up/down/left/right for forward/backward/left/right translation
+# Right thumb-stick left/right for twist
+# Left shoulder button for enable
+# Right shoulder button for enable-turbo
+#
+#          L1                                       R1
+#          L2                                       R2
+#       _=====_                                  _=====_
+#      / _____ \                                / _____ \
+#    +.-'_____'-.------------------------------.-'_____'-.+
+#   /   |     |  '.        S O N Y           .'  |  _  |   \
+#  / ___| /|\ |___ \                        / ___| /_\ |___ \      (Y)
+# / |      |      | ;                      ; | _         _ ||
+# | | <---   ---> | |                      | ||_|       (_)||  (X)     (B)
+# | |___   |   ___| ;                      ; |___       ___||
+# |\    | \|/ |    /  _      ____      _   \    | (X) |    /|      (A)
+# | \   |_____|  .','" "',  (_PS_)  ,'" "', '.  |_____|  .' |
+# |  '-.______.-' /       \        /       \  '-._____.-'   |
+# |               |  LJ   |--------|  RJ   |                |
+# |              /\       /        \       /\               |
+# |             /  '.___.'          '.___.'  \              |
+# |            /                              \             |
+#  \          /                                \           /
+#   \________/                                  \_________/
+#
+#          ^ x
+#          |
+#          |
+#  y <-----+      Accelerometer axes
+#           \
+#            \
+#             > z (out)
+#
+# BUTTON         Value
+#   L1             4
+#   L2             6
+#   R1             5
+#   R2             7
+#   A              1
+#   B              2
+#   X              0
+#   Y              3
+#
+#    AXIS        Value
+# Left Horiz.      0
+# Left Vert.       1
+# Right Horiz.     2
+# Right Vert.      5
+#    L2            3
+#    R2            4
+# D-pad Horiz.     9
+# D-pad Vert.      10
+# Accel x          7
+# Accel y          6
+# Accel z          8
+
 teleop_twist_joy:
   axis_linear:
     x: 1

--- a/dingo_control/launch/teleop.launch
+++ b/dingo_control/launch/teleop.launch
@@ -1,9 +1,18 @@
 <launch>
-  <arg name="joy_dev" default="$(optenv DINGO_JOY_DEV /dev/input/ps4)" />
+  <!-- If false, disable teleop via bluetooth controller -->
   <arg name="joystick" default="true" />
 
+  <!-- The joy device we accept input from -->
+  <arg name="joy_dev" default="$(optenv DINGO_JOY_DEV /dev/input/ps4)" />
+
+  <!--
+    The yaml file with the button mappings.
+    If not set via DINGO_JOY_CONFIG, load the appropriate _diff or _omni file from this package
+  -->
+  <arg name="joy_config" default="$(eval optenv('DINGO_JOY_CONFIG', find('dingo_control') + '/config/teleop_omni.yaml' if int(optenv('DINGO_OMNI', 0)) else find('dingo_control') + '/config/teleop_diff.yaml'))" />
+
   <group if="$(optenv DINGO_OMNI 0)">
-    <rosparam command="load" ns="bluetooth_teleop" file="$(dirname)/../config/teleop_omni.yaml" />
+    <rosparam command="load" ns="bluetooth_teleop" file="$(arg joy_config)" />
     <param name="joy_node/dev" value="$(arg joy_dev)" />
     <arg name="config" value="planar" />
     <node pkg="interactive_marker_twist_server" type="marker_server" name="twist_marker_server">
@@ -11,7 +20,7 @@
     </node>
   </group>
   <group unless="$(optenv DINGO_OMNI 0)">
-    <rosparam command="load" ns="bluetooth_teleop" file="$(dirname)/../config/teleop_diff.yaml" />
+    <rosparam command="load" ns="bluetooth_teleop" file="$(arg joy_config)" />
     <param name="joy_node/dev" value="$(arg joy_dev)" />
     <arg name="config" value="linear" />
     <node pkg="interactive_marker_twist_server" type="marker_server" name="twist_marker_server">

--- a/dingo_control/launch/teleop.launch
+++ b/dingo_control/launch/teleop.launch
@@ -1,9 +1,10 @@
 <launch>
-  <arg name="joy_dev" default="/dev/input/js0" />
+  <arg name="joy_dev" default="$(optenv DINGO_JOY_DEV /dev/input/ps4)" />
   <arg name="joystick" default="true" />
 
   <group if="$(optenv DINGO_OMNI 0)">
     <rosparam command="load" ns="bluetooth_teleop" file="$(dirname)/../config/teleop_omni.yaml" />
+    <param name="joy_node/dev" value="$(arg joy_dev)" />
     <arg name="config" value="planar" />
     <node pkg="interactive_marker_twist_server" type="marker_server" name="twist_marker_server">
       <rosparam command="load" file="$(find interactive_marker_twist_server)/config/$(arg config).yaml" />
@@ -11,6 +12,7 @@
   </group>
   <group unless="$(optenv DINGO_OMNI 0)">
     <rosparam command="load" ns="bluetooth_teleop" file="$(dirname)/../config/teleop_diff.yaml" />
+    <param name="joy_node/dev" value="$(arg joy_dev)" />
     <arg name="config" value="linear" />
     <node pkg="interactive_marker_twist_server" type="marker_server" name="twist_marker_server">
       <rosparam command="load" file="$(find interactive_marker_twist_server)/config/$(arg config).yaml" />


### PR DESCRIPTION
Like the Jackal and Husky, we have a joy_dev argument in the teleop launch file, but it doesn't actually do anything.

This change removes the joy_dev from the yaml files and uses the launch argument. Also adds support for a new DINGO_JOY_DEV environment variable to globally change the joy device.

Also adds joy_config as a launch argument + DINGO_JOY_CONFIG to override the default button mappings more easily.  This is especially useful if you need to use a different controller than the PS4.