### PR TITLE
Simplify customizing ros parameters via CONFIG_EXTRAS env var

### DIFF
--- a/dingo_control/config/empty.yaml
+++ b/dingo_control/config/empty.yaml
@@ -1,0 +1,6 @@
+# The empty Dingo extras configuration has nothing in it and should not.
+# It is meant to override the default to add custom control parameters
+# file in your own Dingo customization package and setting DINGO_CONFIG_EXTRAS
+# to your customization file in the launch file control.launch.
+# Each parameter will need to be loaded in the correct namespace to
+# be used.

--- a/dingo_control/launch/control.launch
+++ b/dingo_control/launch/control.launch
@@ -1,4 +1,6 @@
 <launch>
+  <arg name="config_extras"
+       default="$(eval optenv('DINGO_CONFIG_EXTRAS', find('dingo_control') + '/config/empty.yaml'))"/>
 
   <group if="$(optenv DINGO_OMNI 0)">
     <rosparam command="load" file="$(dirname)/../config/control_omni.yaml" />
@@ -19,8 +21,6 @@
     <remap from="cmd_vel_out" to="dingo_velocity_controller/cmd_vel"/>
   </node>
 
-  <group if="$(optenv DINGO_CONTROL_EXTRAS 0)" >
-    <rosparam command="load" file="$(env DINGO_CONTROL_EXTRAS_PATH)" />
-  </group>
+  <rosparam command="load" file="$(arg config_extras)" />
 
 </launch>


### PR DESCRIPTION
Remove the 0/1 DINGO_CONTROL_EXTRAS + DINGO_CONTROL_EXTRAS_PATH, simplify to just DINGO_CONFIG_EXTRAS, like Husky & Warthog.