### PR TITLE
Add a generic dingo.urdf.xacro

### DIFF
--- a/dingo_description/urdf/dingo.urdf.xacro
+++ b/dingo_description/urdf/dingo.urdf.xacro
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <robot name="dingo" xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:if value="$(optenv DINGO_OMNI 0)">
-    <include filename="$(find dingo_description)/urdf/dingo-o.urdf.xacro" />
+    <xacro:include filename="$(find dingo_description)/urdf/dingo-o.urdf.xacro" />
   </xacro:if>
   <xacro:unless value="$(optenv DINGO_OMNI 0)">
-    <include filename="$(find dingo_description)/urdf/dingo-d.urdf.xacro" />
+    <xacro:include filename="$(find dingo_description)/urdf/dingo-d.urdf.xacro" />
   </xacro:unless>
 </robot>

--- a/dingo_description/urdf/dingo.urdf.xacro
+++ b/dingo_description/urdf/dingo.urdf.xacro
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<robot name="dingo" xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:if value="$(optenv DINGO_OMNI 0)">
+    <include filename="$(find dingo_description)/urdf/dingo-o.urdf.xacro" />
+  </xacro:if>
+  <xacro:unless value="$(optenv DINGO_OMNI 0)">
+    <include filename="$(find dingo_description)/urdf/dingo-d.urdf.xacro" />
+  </xacro:unless>
+</robot>


### PR DESCRIPTION
 This file includes dingo-d or dingo-o as-needed. This simplifies adding support for manipulators to the robot.