### PR TITLE
Update Dingo-O controller mapping, keep legacy file in case

### DIFF
--- a/dingo_control/config/teleop_omni_ps4_legacy.yaml
+++ b/dingo_control/config/teleop_omni_ps4_legacy.yaml
@@ -1,6 +1,6 @@
-# Teleop configuration for PS4 controller.  Some newer controllers use a different
-# order for button and axis indices, which can cause problems when using Dingo-O.
-# If this occurs, try using teleop_omni_ps4_v2.yaml instead of this file.
+# Alternate PS4 controller mapping; some older PS4 controllers seem to use this mapping instead
+# On Dingo-D this won't make much difference, but for Dingo-O the yaw input can be mapped incorrectly
+# between the two versions.
 #
 # Left thumb-stick up/down/left/right for forward/backward/left/right translation
 # Right thumb-stick left/right for twist
@@ -40,20 +40,23 @@
 #   L2             6
 #   R1             5
 #   R2             7
-#   A              0       X-button
-#   B              1       Circle-button
-#   X              3       Squre-button
-#   Y              2       Triangle-button
+#   A              1
+#   B              2
+#   X              0
+#   Y              3
 #
 #    AXIS        Value
 # Left Horiz.      0
 # Left Vert.       1
-#    L2            2
-# Right Horiz.     3
-# Right Vert.      4
-#    R2            5
-# D-pad Horiz.     6
-# D-pad Vert.      7
+# Right Horiz.     2
+# Right Vert.      5
+#    L2            3
+#    R2            4
+# D-pad Horiz.     9
+# D-pad Vert.      10
+# Accel x          7
+# Accel y          6
+# Accel z          8
 
 teleop_twist_joy:
   axis_linear:
@@ -66,7 +69,7 @@ teleop_twist_joy:
     x: 2.0 # TODO: should this be 1.0?
     y: 2.0 # TODO: should this be 1.0?
   axis_angular:
-    yaw: 3
+    yaw: 2
   scale_angular:
     yaw: 1.4 # TODO: should this be 1.0?
   scale_angular_turbo:

--- a/dingo_control/launch/teleop.launch
+++ b/dingo_control/launch/teleop.launch
@@ -8,6 +8,8 @@
   <!--
     The yaml file with the button mappings.
     If not set via DINGO_JOY_CONFIG, load the appropriate _diff or _omni file from this package
+    If you have a Dingo-O and the yaw control is not working as-expected, try setting DINGO_JOY_CONFIG
+    to dingo_control/config/teleop_omni_ps4_legacy.yaml
   -->
   <arg name="joy_config" default="$(eval optenv('DINGO_JOY_CONFIG', find('dingo_control') + '/config/teleop_omni.yaml'
                           if int(optenv('DINGO_OMNI', 0)) else find('dingo_control') + '/config/teleop_diff.yaml'))" />


### PR DESCRIPTION
Ref: RP-2442
It looks like something behind the scenes has changed with the PS4 button & axis ordering.  Not sure when/why this happened, but it's broken the Dingo-O yaw control.
I've checked the new button & axis ordering with 2 different controllers lying around the office (an old one I used to check last time this was a problem) and a freshly-unboxed one on two computers/robots.  All appear to be using the new button & axis ordering.
On the off-chance that the old file is still needed out in the field, I've kept it around as `teleop_omni_ps4_legacy.yaml` and added instructions to teleop.launch specific to Dingo-O.  But from what I can see the new file should be correct moving forward.