### PR TITLE
Update the axes to match the latest DS4DRV update

### DIFF
--- a/dingo_control/config/teleop_omni.yaml
+++ b/dingo_control/config/teleop_omni.yaml
@@ -45,10 +45,10 @@
 #    AXIS        Value
 # Left Horiz.      0
 # Left Vert.       1
-# Right Horiz.     2
-# Right Vert.      5
-#    L2            3
-#    R2            4
+# Right Horiz.     3
+# Right Vert.      4
+#    L2            2
+#    R2            5
 # D-pad Horiz.     9
 # D-pad Vert.      10
 # Accel x          7
@@ -66,7 +66,7 @@ teleop_twist_joy:
     x: 2.0 # TODO: should this be 1.0?
     y: 2.0 # TODO: should this be 1.0?
   axis_angular:
-    yaw: 2
+    yaw: 3
   scale_angular:
     yaw: 1.4 # TODO: should this be 1.0?
   scale_angular_turbo:


### PR DESCRIPTION
The new DS4DRV update is out, which, as far as I've been able to determine, reliably fixes the consistency issues we were having with the axis mapping.
The left stick remains axes 0 & 1, the right stick is axes 3 & 4, the analog triggers are axes 2 & 5.