### PR TITLE
Dingo Secondary Realsense and Velodyne

### DIFF
--- a/dingo_description/urdf/accessories.urdf.xacro
+++ b/dingo_description/urdf/accessories.urdf.xacro
@@ -128,23 +128,51 @@
     - vlp16 (default) :: Velodyne VLP16=
   -->
   <xacro:if value="$(optenv DINGO_LASER_3D 0)">
-    <xacro:property name="mount" value="$(optenv DINGO_LASER_3D_MOUNT front)" />
-    <xacro:property name="topic" value="$(optenv DINGO_LASER_3D_TOPIC front/points)" />
-    <xacro:property name="tower" value="$(optenv DINGO_LASER_3D_TOWER 1)" />
-    <xacro:property name="angle" value="$(optenv DINGO_LASER_3D_ANGLE 0)" />
+    <xacro:property name="mount"  value="$(optenv DINGO_LASER_3D_MOUNT front)" />
+    <xacro:property name="topic"  value="$(optenv DINGO_LASER_3D_TOPIC front/points)" />
+    <xacro:property name="tower"  value="$(optenv DINGO_LASER_3D_TOWER 1)" />
+    <xacro:property name="angle"  value="$(optenv DINGO_LASER_3D_ANGLE 0)" />
     <xacro:property name="prefix" value="$(optenv DINGO_LASER_3D_PREFIX ${mount})" />
     <xacro:property name="parent" value="$(optenv DINGO_LASER_3D_PARENT ${mount}_mount)" />
-    <xacro:property name="lidar_3d_model" value="$(optenv DINGO_LASER_3D_MODEL vlp16)" />
+    <xacro:property name="model"  value="$(optenv DINGO_LASER_3D_MODEL vlp16)" />
+    <xacro:property name="frame"  value="$(optenv DINGO_LASER_3D_FRAME velodyne)" />
+    <xacro:property name="xyz"    value="$(optenv DINGO_LASER_3D_OFFSET 0 0 0)" />
+    <xacro:property name="rpy"    value="$(optenv DINGO_LASER_3D_RPY 0 0 0)" />
     <!-- Velodyne VLP16 -->
-    <xacro:if value="${lidar_3d_model == 'vlp16'}">
-      <xacro:vlp16_mount topic="${topic}" tower="${tower}" angle="${angle}" prefix="${prefix}" parent_link="${parent}" >
-        <origin xyz="$(optenv DINGO_LASER_3D_OFFSET 0 0 0)" rpy="$(optenv DINGO_LASER_3D_RPY 0 0 0)" />
+    <xacro:if value="${model == 'vlp16'}">
+      <xacro:vlp16_mount topic="${topic}" tower="${tower}" angle="${angle}" prefix="${prefix}" parent_link="${parent}" frame_id="${frame}">
+        <origin xyz="${xyz}" rpy="${rpy}" />
       </xacro:vlp16_mount>
     </xacro:if>
     <!-- Velodyne HDL-32E -->
-    <xacro:if value="${lidar_3d_model == 'hdl32e'}">
-      <xacro:hdl32e_mount topic="${topic}" tower="${tower}" angle="${angle}" prefix="${prefix}" parent_link="${parent}" >
-        <origin xyz="$(optenv DINGO_LASER_3D_OFFSET 0 0 0)" rpy="$(optenv DINGO_LASER_3D_RPY 0 0 0)" />
+    <xacro:if value="${model == 'hdl32e'}">
+      <xacro:hdl32e_mount topic="${topic}" tower="${tower}" angle="${angle}" prefix="${prefix}" parent_link="${parent}" frame_id="${frame}">
+        <origin xyz="${xyz}" rpy="${rpy}" />
+      </xacro:hdl32e_mount>
+    </xacro:if>
+  </xacro:if>
+
+  <xacro:if value="$(optenv DINGO_LASER_3D_SECONDARY 0)">
+    <xacro:property name="mount"  value="$(optenv DINGO_LASER_3D_SECONDARY_MOUNT rear)" />
+    <xacro:property name="topic"  value="$(optenv DINGO_LASER_3D_SECONDARY_TOPIC rear/points)" />
+    <xacro:property name="tower"  value="$(optenv DINGO_LASER_3D_SECONDARY_TOWER 1)" />
+    <xacro:property name="angle"  value="$(optenv DINGO_LASER_3D_SECONDARY_ANGLE 0)" />
+    <xacro:property name="prefix" value="$(optenv DINGO_LASER_3D_SECONDARY_PREFIX ${mount})" />
+    <xacro:property name="parent" value="$(optenv DINGO_LASER_3D_SECONDARY_PARENT ${mount}_mount)" />
+    <xacro:property name="model"  value="$(optenv DINGO_LASER_3D_SECONDARY_MODEL vlp16)" />
+    <xacro:property name="frame"  value="$(optenv DINGO_LASER_3D_SECONDARY_FRAME secondary_velodyne)" />
+    <xacro:property name="xyz"    value="$(optenv DINGO_LASER_3D_SECONDARY_OFFSET 0 0 0)" />
+    <xacro:property name="rpy"    value="$(optenv DINGO_LASER_3D_SECONDARY_RPY 0 0 ${M_PI})" />
+    <!-- Velodyne VLP16 -->
+    <xacro:if value="${model == 'vlp16'}">
+      <xacro:vlp16_mount topic="${topic}" tower="${tower}" angle="${angle}" prefix="${prefix}" parent_link="${parent}" frame_id="${frame}">
+        <origin xyz="${xyz}" rpy="${rpy}" />
+      </xacro:vlp16_mount>
+    </xacro:if>
+    <!-- Velodyne HDL-32E -->
+    <xacro:if value="${model == 'hdl32e'}">
+      <xacro:hdl32e_mount topic="${topic}" tower="${tower}" angle="${angle}" prefix="${prefix}" parent_link="${parent}" frame_id="${frame}">
+        <origin xyz="${xyz}" rpy="${rpy}" />
       </xacro:hdl32e_mount>
     </xacro:if>
   </xacro:if>
@@ -160,26 +188,25 @@
     Note: If two realsense's are included, both must be the same model type.
   -->
   <xacro:include filename="$(find dingo_description)/urdf/accessories/intel_realsense.urdf.xacro" />
-  <xacro:property name="realsense_enabled" value="$(optenv DINGO_REALSENSE 0)"/>
   <!-- Primary Realsense Parameters -->
-  <xacro:property name="rs_model"   default="$(optenv DINGO_REALSENSE_MODEL d435)"/>
-  <xacro:property name="rs_topic"   default="$(optenv DINGO_REALSENSE_TOPIC realsense)" />
-  <xacro:property name="rs_mount"   default="$(optenv DINGO_REALSENSE_MOUNT front)" />
-  <xacro:property name="rs_prefix"  default="$(optenv DINGO_REALSENSE_PREFIX ${rs_mount})" />
-  <xacro:property name="rs_parent"  default="$(optenv DINGO_REALSENSE_PARENT ${rs_mount}_mount)" />
-  <xacro:property name="rs_xyz"     default="$(optenv DINGO_REALSENSE_OFFSET 0 0 0)" />
-  <xacro:property name="rs_rpy"     default="$(optenv DINGO_REALSENSE_RPY 0 0 0)" />
+  <xacro:property name="rs_enabled" value="$(optenv DINGO_REALSENSE 0)"/>
+  <xacro:property name="rs_model"   value="$(optenv DINGO_REALSENSE_MODEL d435)"/>
+  <xacro:property name="rs_topic"   value="$(optenv DINGO_REALSENSE_TOPIC realsense)" />
+  <xacro:property name="rs_mount"   value="$(optenv DINGO_REALSENSE_MOUNT front)" />
+  <xacro:property name="rs_prefix"  value="$(optenv DINGO_REALSENSE_PREFIX ${rs_mount})" />
+  <xacro:property name="rs_parent"  value="$(optenv DINGO_REALSENSE_PARENT ${rs_mount}_mount)" />
+  <xacro:property name="rs_xyz"     value="$(optenv DINGO_REALSENSE_OFFSET 0 0 0)" />
+  <xacro:property name="rs_rpy"     value="$(optenv DINGO_REALSENSE_RPY 0 0 0)" />
   <!-- Secondary Realsense Parameters -->
-  <xacro:property name="rs_secondary_enabled" default="$(optenv DINGO_REALSENSE_SECONDARY 0)"/>
-  <xacro:property name="rs_secondary_model"   default="$(optenv DINGO_REALSENSE_SECONDARY_MODEL d435)"/>
-  <xacro:property name="rs_secondary_topic"   default="$(optenv DINGO_REALSENSE_SECONDARY_TOPIC realsense_secondary)" />
-  <xacro:property name="rs_secondary_mount"   default="$(optenv DINGO_REALSENSE_SECONDARY_MOUNT rear)" />
-  <xacro:property name="rs_secondary_prefix"  default="$(optenv DINGO_REALSENSE_SECONDARY_PREFIX ${rs_secondary_mount})" />
-  <xacro:property name="rs_secondary_parent"  default="$(optenv DINGO_REALSENSE_SECONDARY_PARENT ${rs_secondary_mount}_mount)" />
-  <xacro:property name="rs_secondary_xyz"     default="$(optenv DINGO_REALSENSE_SECONDARY_OFFSET 0 0 0)" />
-  <xacro:property name="rs_secondary_rpy"     default="$(optenv DINGO_REALSENSE_SECONDARY_RPY 0 0 ${M_PI})" />
+  <xacro:property name="rs_secondary_enabled" value="$(optenv DINGO_REALSENSE_SECONDARY 0)"/>
+  <xacro:property name="rs_secondary_model"   value="$(optenv DINGO_REALSENSE_SECONDARY_MODEL d435)"/>
+  <xacro:property name="rs_secondary_topic"   value="$(optenv DINGO_REALSENSE_SECONDARY_TOPIC realsense_secondary)" />
+  <xacro:property name="rs_secondary_mount"   value="$(optenv DINGO_REALSENSE_SECONDARY_MOUNT rear)" />
+  <xacro:property name="rs_secondary_prefix"  value="$(optenv DINGO_REALSENSE_SECONDARY_PREFIX ${rs_secondary_mount})" />
+  <xacro:property name="rs_secondary_parent"  value="$(optenv DINGO_REALSENSE_SECONDARY_PARENT ${rs_secondary_mount}_mount)" />
+  <xacro:property name="rs_secondary_xyz"     value="$(optenv DINGO_REALSENSE_SECONDARY_OFFSET 0 0 0)" />
+  <xacro:property name="rs_secondary_rpy"     value="$(optenv DINGO_REALSENSE_SECONDARY_RPY 0 0 ${M_PI})" />
   <!-- Includes Required for `realsense_sensor` -->
-  <xacro:property name="rs_model"   default="$(optenv DINGO_REALSENSE_MODEL d435)"/>
   <xacro:if value="${rs_model == 'd435'}">
     <xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro" />
   </xacro:if>
@@ -193,20 +220,22 @@
     <xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro" />
   </xacro:if>
 
-  <xacro:if value="${realsense_enabled}">
+  <xacro:if value="${rs_enabled}">
     <xacro:realsense_sensor rs_model="${rs_model}"
                             prefix="${rs_prefix}"
                             parent="${rs_parent}"
-                            topic="${rs_topic}">
+                            topic="${rs_topic}"
+                            include="0">
       <origin xyz="${rs_xyz}" rpy="${rs_rpy}"/>
     </xacro:realsense_sensor>
   </xacro:if>
 
-  <xacro:if value="${realsense_secondary_enabled}">
+  <xacro:if value="${rs_secondary_enabled}">
     <xacro:realsense_sensor rs_model="${rs_secondary_model}"
                             prefix="${rs_secondary_prefix}"
                             parent="${rs_secondary_parent}"
-                            topic="${rs_secondary_topic}">
+                            topic="${rs_secondary_topic}"
+                            include="0">
       <origin xyz="${rs_secondary_xyz}" rpy="${rs_secondary_rpy}"/>
     </xacro:realsense_sensor>
   </xacro:if>

--- a/dingo_description/urdf/accessories.urdf.xacro
+++ b/dingo_description/urdf/accessories.urdf.xacro
@@ -157,12 +157,58 @@
     - d415
     - d455
     - l515
+    Note: If two realsense's are included, both must be the same model type.
   -->
-  <xacro:if value="$(optenv DINGO_REALSENSE 0)">
-    <xacro:include filename="$(find dingo_description)/urdf/accessories/intel_realsense.urdf.xacro" />
-    <xacro:realsense_sensor rs_model="$(optenv DINGO_REALSENSE_MODEL d435)"
-                            prefix="$(optenv DINGO_REALSENSE_MOUNT front)"
-                            topic="$(optenv DINGO_REALSENSE_TOPIC realsense)" />
+  <xacro:include filename="$(find dingo_description)/urdf/accessories/intel_realsense.urdf.xacro" />
+  <xacro:property name="realsense_enabled" value="$(optenv DINGO_REALSENSE 0)"/>
+  <!-- Primary Realsense Parameters -->
+  <xacro:property name="rs_model"   default="$(optenv DINGO_REALSENSE_MODEL d435)"/>
+  <xacro:property name="rs_topic"   default="$(optenv DINGO_REALSENSE_TOPIC realsense)" />
+  <xacro:property name="rs_mount"   default="$(optenv DINGO_REALSENSE_MOUNT front)" />
+  <xacro:property name="rs_prefix"  default="$(optenv DINGO_REALSENSE_PREFIX ${rs_mount})" />
+  <xacro:property name="rs_parent"  default="$(optenv DINGO_REALSENSE_PARENT ${rs_mount}_mount)" />
+  <xacro:property name="rs_xyz"     default="$(optenv DINGO_REALSENSE_OFFSET 0 0 0)" />
+  <xacro:property name="rs_rpy"     default="$(optenv DINGO_REALSENSE_RPY 0 0 0)" />
+  <!-- Secondary Realsense Parameters -->
+  <xacro:property name="rs_secondary_enabled" default="$(optenv DINGO_REALSENSE_SECONDARY 0)"/>
+  <xacro:property name="rs_secondary_model"   default="$(optenv DINGO_REALSENSE_SECONDARY_MODEL d435)"/>
+  <xacro:property name="rs_secondary_topic"   default="$(optenv DINGO_REALSENSE_SECONDARY_TOPIC realsense_secondary)" />
+  <xacro:property name="rs_secondary_mount"   default="$(optenv DINGO_REALSENSE_SECONDARY_MOUNT rear)" />
+  <xacro:property name="rs_secondary_prefix"  default="$(optenv DINGO_REALSENSE_SECONDARY_PREFIX ${rs_secondary_mount})" />
+  <xacro:property name="rs_secondary_parent"  default="$(optenv DINGO_REALSENSE_SECONDARY_PARENT ${rs_secondary_mount}_mount)" />
+  <xacro:property name="rs_secondary_xyz"     default="$(optenv DINGO_REALSENSE_SECONDARY_OFFSET 0 0 0)" />
+  <xacro:property name="rs_secondary_rpy"     default="$(optenv DINGO_REALSENSE_SECONDARY_RPY 0 0 ${M_PI})" />
+  <!-- Includes Required for `realsense_sensor` -->
+  <xacro:property name="rs_model"   default="$(optenv DINGO_REALSENSE_MODEL d435)"/>
+  <xacro:if value="${rs_model == 'd435'}">
+    <xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro" />
+  </xacro:if>
+  <xacro:if value="${rs_model == 'd435i'}">
+    <xacro:include filename="$(find realsense2_description)/urdf/_d435i.urdf.xacro" />
+  </xacro:if>
+  <xacro:if value="${rs_model == 'd415'}">
+    <xacro:include filename="$(find realsense2_description)/urdf/_d415.urdf.xacro" />
+  </xacro:if>
+  <xacro:if value="${rs_model == 'd455'}">
+    <xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro" />
+  </xacro:if>
+
+  <xacro:if value="${realsense_enabled}">
+    <xacro:realsense_sensor rs_model="${rs_model}"
+                            prefix="${rs_prefix}"
+                            parent="${rs_parent}"
+                            topic="${rs_topic}">
+      <origin xyz="${rs_xyz}" rpy="${rs_rpy}"/>
+    </xacro:realsense_sensor>
+  </xacro:if>
+
+  <xacro:if value="${realsense_secondary_enabled}">
+    <xacro:realsense_sensor rs_model="${rs_secondary_model}"
+                            prefix="${rs_secondary_prefix}"
+                            parent="${rs_secondary_parent}"
+                            topic="${rs_secondary_topic}">
+      <origin xyz="${rs_secondary_xyz}" rpy="${rs_secondary_rpy}"/>
+    </xacro:realsense_sensor>
   </xacro:if>
 
   <!--

--- a/dingo_description/urdf/accessories/hdl32_mount.urdf.xacro
+++ b/dingo_description/urdf/accessories/hdl32_mount.urdf.xacro
@@ -1,7 +1,7 @@
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find velodyne_description)/urdf/HDL-32E.urdf.xacro" />
 
-  <xacro:macro name="hdl32e_mount" params="prefix parent_link topic tower angle:=0.0 *origin">
+  <xacro:macro name="hdl32e_mount" params="prefix parent_link topic tower frame_id:=velodyne angle:=0.0 *origin">
     <xacro:if value="${tower}">
       <link name="${prefix}_hdl32e_mount">
         <visual>
@@ -26,7 +26,7 @@
       </joint>
 
       <!-- Velodyne HDL-32E Macro treats Y-axis as forward in pointcloud --> 
-      <xacro:HDL-32E parent="${prefix}_hdl32e_mount" topic="${topic}">
+      <xacro:HDL-32E parent="${prefix}_hdl32e_mount" topic="${topic}" name="${frame_id}">
         <origin xyz="0 0 0.081" rpy="0 0 ${angle - 1.5707}"/>
       </xacro:HDL-32E>
     </xacro:if>
@@ -38,7 +38,7 @@
         <xacro:insert_block name="origin" />      
       </joint>
       <!-- Velodyne HDL-32E Macro treats Y-axis as forward in pointcloud --> 
-      <xacro:HDL-32E parent="${prefix}_hdl32e_mount" topic="${topic}">
+      <xacro:HDL-32E parent="${prefix}_hdl32e_mount" topic="${topic}" name="${frame_id}">
         <origin xyz="0 0 0" rpy="0 0 ${angle - 1.5707}"/>
       </xacro:HDL-32E>
     </xacro:unless>

--- a/dingo_description/urdf/accessories/intel_realsense.urdf.xacro
+++ b/dingo_description/urdf/accessories/intel_realsense.urdf.xacro
@@ -8,9 +8,9 @@
 <!-- IMPORTANT NOTE FOR MULTIPLE REALSENSES:
   As of Sept. 2022, due to limitations with the 'realsense2_description' package 
   (see realsense2_description/urdf/_materials.xacro.urdf):
-   the include parameter 
-  must be set to FALSE, and the following files must be
-  included in the parent xacro file that will include this one:
+    1. the include parameter must be set to FALSE, and
+    2. the following files must be included in the parent xacro file that will 
+        include this one:
   '''
   <xacro:if value="${rs_model == 'd435'}">
     <xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro" />
@@ -25,8 +25,12 @@
     <xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro" />
   </xacro:if>
   '''
+
   Multiple inclusions of any of these files (even when namespaced), will define
   the materials at a global level, violating uniqueness property of xacro materials.
+
+  Therefore, it is not possible at this time to have different models of Realsense 
+  cameras on the same URDF, without modifying the `realsense2_description` package.
  -->
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:macro name="realsense_sensor" params="

--- a/dingo_description/urdf/accessories/intel_realsense.urdf.xacro
+++ b/dingo_description/urdf/accessories/intel_realsense.urdf.xacro
@@ -4,14 +4,38 @@
   file is a wrapper or the realsense2_description macro that also uses the kinect
   gazebo plugin to simulate data from the camera
 -->
+
+<!-- IMPORTANT NOTE:
+  As of Sept. 2022, due to limitations with the 'realsense2_description' package (see
+  realsense2_description/urdf/_materials.xacro.urdf), the following files must be
+  included in the parent xacro file that will include this one:
+  '''
+  <xacro:if value="${rs_model == 'd435'}">
+    <xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro" />
+  </xacro:if>
+  <xacro:if value="${rs_model == 'd435i'}">
+    <xacro:include filename="$(find realsense2_description)/urdf/_d435i.urdf.xacro" />
+  </xacro:if>
+  <xacro:if value="${rs_model == 'd415'}">
+    <xacro:include filename="$(find realsense2_description)/urdf/_d415.urdf.xacro" />
+  </xacro:if>
+  <xacro:if value="${rs_model == 'd455'}">
+    <xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro" />
+  </xacro:if>
+  '''
+  Multiple inclusions of any of these files (even when namespaced), will define
+  the materials at a global level, violating uniqueness property of xacro materials.
+ -->
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:macro name="realsense_sensor" params="
                rs_model:=d435
                prefix:=front
+               parent:=front_mount
                topic:=realsense
                width:=680
                height:=480
-               update_rate:=30">
+               update_rate:=30
+               *origin">
 
     <xacro:macro name="realsense_gazebo" params="
               prefix=front              model=d4
@@ -85,10 +109,9 @@
     </xacro:macro>
 
     <xacro:if value="${rs_model == 'd435'}">
-      <xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro" />
-      <xacro:sensor_d435 parent="${prefix}_mount"
+      <xacro:sensor_d435 parent="${parent}"
                         name="${prefix}_realsense">
-        <origin xyz="$(optenv DINGO_REALSENSE_OFFSET 0 0 0)" rpy="$(optenv DINGO_REALSENSE_RPY 0 0 0)" />
+        <xacro:insert_block name="origin"/>
       </xacro:sensor_d435>
 
       <xacro:realsense_gazebo
@@ -105,16 +128,15 @@
     </xacro:if>
 
     <xacro:if value="${rs_model == 'd435i'}">
-      <xacro:include filename="$(find realsense2_description)/urdf/_d435i.urdf.xacro" />
-      <xacro:sensor_d435i parent="$(optenv DINGO_REALSENSE_MOUNT front)_mount"
-                          name="$(optenv DINGO_REALSENSE_MOUNT front)_realsense">
-        <origin xyz="$(optenv DINGO_REALSENSE_OFFSET 0 0 0)" rpy="$(optenv DINGO_REALSENSE_RPY 0 0 0)" />
+      <xacro:sensor_d435i parent="${parent}"
+                          name="${prefix}_realsense">
+        <xacro:insert_block name="origin"/>
       </xacro:sensor_d435i>
 
       <xacro:realsense_gazebo
-         prefix="$(optenv DINGO_REALSENSE_MOUNT front)"
-         frame="$(optenv DINGO_REALSENSE_MOUNT front)_realsense_link"
-         topic="$(optenv DINGO_REALSENSE_TOPIC realsense)"
+         prefix="${prefix}"
+         frame="${prefix}_realsense_link"
+         topic="${topic}"
          h_fov="1.5184351666666667"
          v_fov="1.0122901111111111"
          min_range="0.105"
@@ -132,8 +154,8 @@
         <plugin name="d435_accel" filename="libhector_gazebo_ros_imu.so">
           <robotNamespace>/</robotNamespace>
           <updateRate>30.0</updateRate>
-          <bodyName>$(optenv DINGO_REALSENSE_MOUNT front)_realsense_link</bodyName>
-          <topicName>$(optenv DINGO_REALSENSE_TOPIC realsense)/accel/sample</topicName>
+          <bodyName>${prefix}_realsense_link</bodyName>
+          <topicName>${topic}/accel/sample</topicName>
           <accelDrift>0.005 0.005 0.005</accelDrift>
           <accelGaussianNoise>0.005 0.005 0.005</accelGaussianNoise>
           <rateDrift>0.005 0.005 0.005 </rateDrift>
@@ -144,8 +166,8 @@
         <plugin name="d435_gyro" filename="libhector_gazebo_ros_imu.so">
           <robotNamespace>/</robotNamespace>
           <updateRate>30.0</updateRate>
-          <bodyName>$(optenv DINGO_REALSENSE_MOUNT front)_realsense_link</bodyName>
-          <topicName>$(optenv DINGO_REALSENSE_TOPIC realsense)/gyro/sample</topicName>
+          <bodyName>${prefix}_realsense_link</bodyName>
+          <topicName>${topic}/gyro/sample</topicName>
           <accelDrift>0.005 0.005 0.005</accelDrift>
           <accelGaussianNoise>0.005 0.005 0.005</accelGaussianNoise>
           <rateDrift>0.005 0.005 0.005 </rateDrift>
@@ -157,16 +179,15 @@
     </xacro:if>
 
     <xacro:if value="${rs_model == 'd415'}">
-      <xacro:include filename="$(find realsense2_description)/urdf/_d415.urdf.xacro" />
-      <xacro:sensor_d415 parent="$(optenv DINGO_REALSENSE_MOUNT front)_mount"
-                         name="$(optenv DINGO_REALSENSE_MOUNT front)_realsense">
-        <origin xyz="$(optenv DINGO_REALSENSE_OFFSET 0 0 0)" rpy="$(optenv DINGO_REALSENSE_RPY 0 0 0)" />
+      <xacro:sensor_d415 parent="${parent}"
+                         name="${prefix}_realsense">
+        <xacro:insert_block name="origin"/>
       </xacro:sensor_d415>
 
       <xacro:realsense_gazebo
-         prefix="$(optenv DINGO_REALSENSE_MOUNT front)"
-         frame="$(optenv DINGO_REALSENSE_MOUNT front)_realsense_link"
-         topic="$(optenv DINGO_REALSENSE_TOPIC realsense)"
+         prefix="${prefix}"
+         frame="${prefix}_realsense_link"
+         topic="${topic}"
          h_fov="1.1344640137963142"
          v_fov="0.6981317007977318"
          min_range="0.3"
@@ -178,16 +199,15 @@
 
     <xacro:if value="${rs_model == 'd455'}">
       <!-- TODO: not officially supported yet. Use the D435 mesh for now, even though it's the wrong size -->
-      <xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro" />
-      <xacro:sensor_d435 parent="$(optenv DINGO_REALSENSE_MOUNT front)_mount"
-                         name="$(optenv DINGO_REALSENSE_MOUNT front)_realsense">
-        <origin xyz="$(optenv DINGO_REALSENSE_OFFSET 0 0 0)" rpy="$(optenv DINGO_REALSENSE_RPY 0 0 0)" />
+      <xacro:sensor_d435 parent="${parent}"
+                         name="${prefix}_realsense">
+        <xacro:insert_block name="origin"/>
       </xacro:sensor_d435>
 
       <xacro:realsense_gazebo
-         prefix="$(optenv DINGO_REALSENSE_MOUNT front)"
-         frame="$(optenv DINGO_REALSENSE_MOUNT front)_realsense_link"
-         topic="$(optenv DINGO_REALSENSE_TOPIC realsense)"
+         prefix="${prefix}"
+         frame="${prefix}_realsense_link"
+         topic="${topic}"
          h_fov="1.5009831567151233"
          v_fov="0.9948376736367678"
          min_range="0.5"
@@ -235,15 +255,15 @@
         <origin xyz="0 0 0.0305" rpy="0 0 0" />
       </joint>
       <joint type="fixed" name="${prefix}_realsense_mount_joint">
-        <parent link="${prefix}_mount" />
+        <parent link="${parent}" />
         <child link="${prefix}_realsense_bottom_screw_frame" />
         <origin xyz="0 0 0.004" rpy="0 0 0" />
       </joint>
 
       <xacro:realsense_gazebo
-         prefix="$(optenv DINGO_REALSENSE_MOUNT front)"
-         frame="$(optenv DINGO_REALSENSE_MOUNT front)_realsense_link"
-         topic="$(optenv DINGO_REALSENSE_TOPIC realsense)"
+         prefix="${prefix}"
+         frame="${prefix}_realsense_link"
+         topic="${topic}"
          h_fov="1.2217304763960306"
          v_fov="0.9599310885968813"
          min_range="0.25"

--- a/dingo_description/urdf/accessories/intel_realsense.urdf.xacro
+++ b/dingo_description/urdf/accessories/intel_realsense.urdf.xacro
@@ -5,9 +5,11 @@
   gazebo plugin to simulate data from the camera
 -->
 
-<!-- IMPORTANT NOTE:
-  As of Sept. 2022, due to limitations with the 'realsense2_description' package (see
-  realsense2_description/urdf/_materials.xacro.urdf), the following files must be
+<!-- IMPORTANT NOTE FOR MULTIPLE REALSENSES:
+  As of Sept. 2022, due to limitations with the 'realsense2_description' package 
+  (see realsense2_description/urdf/_materials.xacro.urdf):
+   the include parameter 
+  must be set to FALSE, and the following files must be
   included in the parent xacro file that will include this one:
   '''
   <xacro:if value="${rs_model == 'd435'}">
@@ -35,7 +37,23 @@
                width:=680
                height:=480
                update_rate:=30
+               include:=1
                *origin">
+
+    <xacro:if value="${include}">
+      <xacro:if value="${rs_model == 'd435'}">
+        <xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro" />
+      </xacro:if>
+      <xacro:if value="${rs_model == 'd435i'}">
+        <xacro:include filename="$(find realsense2_description)/urdf/_d435i.urdf.xacro" />
+      </xacro:if>
+      <xacro:if value="${rs_model == 'd415'}">
+        <xacro:include filename="$(find realsense2_description)/urdf/_d415.urdf.xacro" />
+      </xacro:if>
+      <xacro:if value="${rs_model == 'd455'}">
+        <xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro" />
+      </xacro:if>
+    </xacro:if>
 
     <xacro:macro name="realsense_gazebo" params="
               prefix=front              model=d4

--- a/dingo_description/urdf/accessories/vlp16_mount.urdf.xacro
+++ b/dingo_description/urdf/accessories/vlp16_mount.urdf.xacro
@@ -1,7 +1,7 @@
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find velodyne_description)/urdf/VLP-16.urdf.xacro" />
 
-  <xacro:macro name="vlp16_mount" params="prefix parent_link topic tower angle:=0 height:=0.1 *origin">
+  <xacro:macro name="vlp16_mount" params="prefix parent_link topic tower frame_id:=velodyne angle:=0 height:=0.1 *origin">
     <xacro:if value="${tower}">
       <link name="${prefix}_vlp16_mount" />
 
@@ -91,12 +91,12 @@
         <origin xyz="0 0 ${height}" rpy="0 0 0" />
       </joint>
 
-      <xacro:VLP-16 parent="${prefix}_vlp16_plate" topic="${topic}">
+      <xacro:VLP-16 parent="${prefix}_vlp16_plate" topic="${topic}" name="${frame_id}">
         <origin xyz="0 0 0" rpy="0 0 ${angle}" />
       </xacro:VLP-16>
     </xacro:if>
     <xacro:unless value="${tower}">
-      <xacro:VLP-16 parent="${parent_link}" topic="${topic}">
+      <xacro:VLP-16 parent="${parent_link}" topic="${topic}" name="${frame_id}">
         <xacro:insert_block name="origin" />
       </xacro:VLP-16>
     </xacro:unless>

--- a/dingo_description/urdf/dingo-d.urdf.xacro
+++ b/dingo_description/urdf/dingo-d.urdf.xacro
@@ -85,7 +85,7 @@
       <geometry>
         <sphere radius="0.01"/>
       </geometry>
-      <material name="Black"/>
+      <material name="black"/>
     </visual>
     <collision>
       <geometry>


### PR DESCRIPTION
Added secondary Velodyne:
- frame environment variable that sets the name of the link that will be used by the driver 
- frame parameter added to VLP16 mount and HDL32e mount URDF's

Added secondary Realsense:
- Multiple includes of any `realsense2_description` URDF will cause redefinition of global material `aluminum`
- Wrapped includes in a conditional that can be passed as a parameter (i.e. `include`)
- Includes from within another include do not add non-global macros to the parent XACRO (i.e. accessories.urdf.xacro). Therefore, we cannot have the first include of the `intel_realsense.urdf.xacro` to include, for example, the `_d435.xacro.urdf` (by passing `include="1"`) and have the second one not do the include (`include="0"`) and instantiate `xacro:sensor_d435` because it would not be known in that namespace. 
- Solution: include the `realsense2_description` URDF in `accessories.urdf.xacro` and then disable includes within `intel_realsense.urdf.xacro`